### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3 
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/flutter-gh-pages@v7
 ```

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2 # Only works with v2
-      - uses: subosito/flutter-action@v1
+      - uses: actions/checkout@v3 
+      - uses: subosito/flutter-action@v2
       - uses: bluefireteam/flutter-gh-pages@v7
 ```
 To build a project in a folder other that the root, use the `workingDir` property


### PR DESCRIPTION
Github action build process fails because deprecated actions. actions/checkout@v2 and subosito/flutter-action@v1 makes use of Node 12. 

All actions now make use of Node 16. Hence, the updated README.md