### PR TITLE
Add option to deploy both canvasKit and HTML renderers to the same page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ More on web renderers here: https://flutter.dev/docs/development/tools/web-rende
           webRenderer: canvaskit
 ```
 
+The possible values for webRenderer are:
+
+- auto: Use the default Flutter setting, which is based on the device and browser capabilities.
+- canvaskit: Use the CanvasKit renderer, which uses WebGL and WebAssembly to render graphics.
+- html: Use the HTML renderer, which uses DOM elements and CSS to render graphics.
+- both: Use both renderers and generate two versions of the web app, one in the root folder (here would be the CanvasKit version) and one in a subfolder specified by the htmlFolder property.
+
+If you use both as the webRenderer value, you can also specify the name of the subfolder where the HTML version will be placed, using the htmlFolder property. The default value is htmlVersion.
+
 By default, the action will send the files to the `gh-pages` branch, which is the default used by Github Pages.
 If you need to change that, the `targetBranch` property can be used
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,18 @@ The possible values for webRenderer are:
 - auto: Use the default Flutter setting, which is based on the device and browser capabilities.
 - canvaskit: Use the CanvasKit renderer, which uses WebGL and WebAssembly to render graphics.
 - html: Use the HTML renderer, which uses DOM elements and CSS to render graphics.
-- both: Use both renderers and generate two versions of the web app, one in the root folder (here would be the CanvasKit version) and one in a subfolder specified by the htmlFolder property.
+- both: Use both renderers and generate two versions of the web app, one in the root folder (here would be the CanvasKit version) and one in a subfolder specified by the htmlRoute property.
 
 If you use both as the webRenderer value, you can also specify the name of the subfolder where the HTML version will be placed, using the htmlFolder property. The default value is htmlVersion.
+
+If you've selected the `both` value for the webRenderer, the HTML variant will be deployed to the `htmlRoute` directory. By default, this is set to `htmlVersion`.
+
+```yml
+      ...
+      - uses: bluefireteam/flutter-gh-pages@v7
+        with:
+          htmlRoute: another-route
+```
 
 By default, the action will send the files to the `gh-pages` branch, which is the default used by Github Pages.
 If you need to change that, the `targetBranch` property can be used

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   webRenderer:
-    description: 'Which web renderer to be used, default is auto'
+    description: 'Which web renderer to be used, default is auto. Use both to build both variants.'
     required: false
     default: auto
   workingDir:
@@ -26,6 +26,10 @@ inputs:
     description: 'Custom args like: --dart-define="simple=example"'
     required: false
     default:
+  htmlDir:
+    description: 'The name of the subdirectory where the html variant will be deployed (default htmlVersion)'
+    required: false
+    default: htmlVersion
 
 runs:
   using: 'composite'
@@ -33,7 +37,15 @@ runs:
     - run: flutter config --enable-web
       shell: bash
       working-directory: ${{inputs.workingDir}}
-    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
+    - run: |
+        if [ "${{inputs.webRenderer}}" = "both" ]; then
+          flutter build web --release --web-renderer=canvaskit --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
+          mv build/web build/canvaskit
+          flutter build web --release --web-renderer=html --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
+          mv build/web build/html
+        else
+          flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
+        fi
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git config user.name github-actions
@@ -42,7 +54,11 @@ runs:
     - run: git config user.email github-actions@github.com
       shell: bash
       working-directory: ${{inputs.workingDir}}
-    - run: git --work-tree build/web add --all
+    - run: |
+        git --work-tree build add --all
+        if [ "${{inputs.webRenderer}}" = "both" ]; then
+          mv build/html build/web/${{inputs.htmlDir}}
+        fi
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git commit -m "Automatic deployment by github-actions"

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
 
           flutter build web --release --web-renderer=canvaskit --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
           mv build/web/* build/.
-          rm build/web/
+          rmdir build/web/
         else
           flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
         fi

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,9 @@ runs:
     - run: |
         git --work-tree build add --all
         if [ "${{inputs.webRenderer}}" = "both" ]; then
-          mv build/html build/web/${{inputs.htmlDir}}
+          mkdir -p build/web/${{inputs.htmlDir}}
+          mv build/html/* build/web/${{inputs.htmlDir}}/
+          mv build/canvaskit/* build/web/
         fi
       shell: bash
       working-directory: ${{inputs.workingDir}}

--- a/action.yml
+++ b/action.yml
@@ -39,10 +39,10 @@ runs:
       working-directory: ${{inputs.workingDir}}
     - run: |
         if [ "${{inputs.webRenderer}}" = "both" ]; then
+          flutter build web --release --web-renderer=html --base-href ${{inputs.baseHref}}${{inputs.htmlDir}}/ ${{inputs.customArgs}}
+          mv build/web build/${{inputs.htmlDir}}
+
           flutter build web --release --web-renderer=canvaskit --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
-          mv build/web build/canvaskit
-          flutter build web --release --web-renderer=html --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
-          mv build/web build/html
         else
           flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
         fi
@@ -56,11 +56,6 @@ runs:
       working-directory: ${{inputs.workingDir}}
     - run: |
         git --work-tree build add --all
-        if [ "${{inputs.webRenderer}}" = "both" ]; then
-          mkdir -p build/web/${{inputs.htmlDir}}
-          mv build/html/* build/web/${{inputs.htmlDir}}/
-          mv build/canvaskit/* build/web/
-        fi
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git commit -m "Automatic deployment by github-actions"

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,8 @@ runs:
           mv build/web build/${{inputs.htmlDir}}
 
           flutter build web --release --web-renderer=canvaskit --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
+          mv build/web/* build/.
+          rm build/web/
         else
           flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
         fi

--- a/action.yml
+++ b/action.yml
@@ -26,8 +26,8 @@ inputs:
     description: 'Custom args like: --dart-define="simple=example"'
     required: false
     default:
-  htmlDir:
-    description: 'The name of the subdirectory where the html variant will be deployed (default htmlVersion)'
+  htmlRoute:
+    description: 'When webRenderer is set to both, the name of the page route where the html variant will be deployed (default htmlVersion)'
     required: false
     default: htmlVersion
 
@@ -39,12 +39,12 @@ runs:
       working-directory: ${{inputs.workingDir}}
     - run: |
         if [ "${{inputs.webRenderer}}" = "both" ]; then
-          flutter build web --release --web-renderer=html --base-href ${{inputs.baseHref}}${{inputs.htmlDir}}/ ${{inputs.customArgs}}
-          mv build/web build/${{inputs.htmlDir}}
+          flutter build web --release --web-renderer=html --base-href ${{inputs.baseHref}}${{inputs.htmlRoute}}/ ${{inputs.customArgs}}
+          mv build/web build/${{inputs.htmlRoute}}
 
           flutter build web --release --web-renderer=canvaskit --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
           mv build/web/* build/.
-          rmdir build/web/
+          rm -rf build/web/
         else
           flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
         fi


### PR DESCRIPTION
While working on a small [project](https://github.com/anleac/defend_your_flame) of mine; I came across heavy performance issues with FireFox (and also Safari!) on MacOS, using `CanvasKit`.

The **TLDR** was, this led me down a rabbithole, which little success in alternatives, while recognizing that using the `HTML` renderer did appear to still perform well on FireFox.

Therefore, I wanted to update this script to actually be able to:
- Provide a new `both` option to the `webRenderer` item which would:
   - Still render to `canvasKit` by default, which is hosted at the base URL
   - Now _also_ renders the `html` version, and hosts this in the subdirectory [GITHUB_PAGE_URL}/htmlVersion (or value of `htmlRoute` if you'd like to change it!)
   
I also updated the documentation / readme, though more than happy to update this in terms of naming if people have strong opinions.

If you'd like to try out the script, feel free to target my pre-release on my fork here: https://github.com/anleac/flutter-gh-pages/releases/tag/v0.6

You can also see it running here: https://github.com/anleac/defend_your_flame/actions/runs/8130571986/job/22218920851
Which deploys to:
- canvasKit: https://anleac.github.io/defend_your_flame/
- html: https://anleac.github.io/defend_your_flame/htmlVersion