### PR TITLE
Ignore web renderer argument if flutter is 3.29.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ To build a project in a folder other that the root, use the `workingDir` propert
 ```
 
 By default, the action will use the auto setting for web renderers, to change that you can use the `webRenderer` property.
+<br>
+Note: the --web-renderer argument is deprecated in flutter 3.29.0 hence it will be ignored flutter version is or above 3.29.0
 
 More on web renderers here: https://flutter.dev/docs/development/tools/web-renderers
 

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,18 @@ runs:
   steps:
     - run: flutter config --enable-web
       shell: bash
-      working-directory: ${{inputs.workingDir}}
+    - run: echo "$(flutter --version | awk '{print $2}' | tr -dc '0-9')"
+      shell: bash
+    - run: echo "flutter_version=$(flutter --version | awk '{print $2}' | tr -dc '0-9')" >> $GITHUB_ENV
+      shell: bash
     - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
+      # run only if flutter version < 329
+      if: ${{ env.flutter_version < 3290 }}
+      shell: bash
+      working-directory: ${{inputs.workingDir}}
+    - run: flutter build web --release --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
+      # run only if flutter version >= 329
+      if: ${{ env.flutter_version >= 3290 }}
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git config user.name github-actions

--- a/action.yml
+++ b/action.yml
@@ -30,17 +30,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: flutter config --enable-web
-      shell: bash
     - run: echo "flutter_version=$(flutter --version | awk '{print $2}' | tr -dc '0-9')" >> $GITHUB_ENV
       shell: bash
+    - run: flutter config --enable-web
+      shell: bash
+      working-directory: ${{inputs.workingDir}}
     - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
-      # run only if flutter version < 329
       if: ${{ env.flutter_version < 3290 }}
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: flutter build web --release --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
-      # run only if flutter version >= 329
       if: ${{ env.flutter_version >= 3290 }}
       shell: bash
       working-directory: ${{inputs.workingDir}}

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,6 @@ runs:
   steps:
     - run: flutter config --enable-web
       shell: bash
-    - run: echo "$(flutter --version | awk '{print $2}' | tr -dc '0-9')"
-      shell: bash
     - run: echo "flutter_version=$(flutter --version | awk '{print $2}' | tr -dc '0-9')" >> $GITHUB_ENV
       shell: bash
     - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}


### PR DESCRIPTION
the --web-renderer argument is deprecrated and because of this build web command fails. to fix this first check flutter version and if it >= 3.29.0 remove the --web-renderer argument.